### PR TITLE
Fix keyboard repeat rate persistence

### DIFF
--- a/src/lxinput.c
+++ b/src/lxinput.c
@@ -772,7 +772,7 @@ int main(int argc, char** argv)
                                   _("LXInput autostart"),
                                   _("Setup keyboard and mouse using settings done in LXInput"),
                                   /* FIXME: how to setup left-handed mouse? */
-                                  accel, threshold, delay, interval,
+                                  accel, threshold, delay, 1000 / interval,
                                   beep ? "on" : "off",
                                   left_handed ? ";xmodmap -e \"pointer = 3 2 1\"" : "",
                                   mstr);


### PR DESCRIPTION
Keyboard repeat-delay and repeat-rate are persisted using xset.

The first argument, repeat-delay, is specified as the number of
milliseconds before autorepeat starts. Unlike the second argument,
repeat-rate, which is instead specified as repeats per second.

This differs to XkbSetAutoRepeatRate() where both those arguments are
specified in milliseconds.